### PR TITLE
Add prepublishOnly script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,12 @@
     "build": "rm -rf lib && tsc",
     "build:parcel": "rm -rf lib && parcel build src/index.tsx --dist-dir lib",
     "test": "npm run lint",
-    "lint": "node_modules/.bin/eslint './src/**/*.tsx' './src/**/*.ts'"
+    "lint": "node_modules/.bin/eslint './src/**/*.tsx' './src/**/*.ts'",
+    "prepublishOnly": "npm run build:parcel"
   },
+  "files": [
+    "lib/"
+  ],
   "keywords": [
     "react",
     "amazon",


### PR DESCRIPTION
This will prevent not publishing the compiled files to npm.

The latest version was published without them: 
https://unpkg.com/browse/react-aim-menu@1.2.0/

Running `npm publish`:
<img width="921" alt="CleanShot 2021-11-30 at 15 49 18@2x" src="https://user-images.githubusercontent.com/284515/144109155-06b18132-f3da-4a76-abd5-b5e960fba699.png">
